### PR TITLE
Pull request - Fixed error 'Undefined variable: releases' when deleting a release.

### DIFF
--- a/remove_blacklist_releases.php
+++ b/remove_blacklist_releases.php
@@ -236,7 +236,7 @@ class blacklistReleases
                         // Remove release
                         if( defined('REMOVE') && true === REMOVE )
                         {
-                            $releases->delete( $match['ID'] );
+                            $this->releases->delete( $match['ID'] );
                         }
                     }
 


### PR DESCRIPTION
When you want to delete a release of a found blacklist match, you would get an error on a undefined variable 'releases'. This pull request fixes the pointer to the correct object containing the releases.
